### PR TITLE
Handle non-jpeg types

### DIFF
--- a/journey2dayonejson.py
+++ b/journey2dayonejson.py
@@ -20,13 +20,15 @@ def convert_unixtime(unixtime, timezone_str):
 
 
 def convert_photo(name, i):
+    md5, type = os.path.splitext(name)
+    type = type[1:] if len(type) else type
     return {
         "orderInEntry": i,
         "identifier": getuuid(),
-        "type": "jpeg",
+        "type": type,
         "isSketch": False,
         "creationDevice": "Joe's MacBook Pro",
-        "md5": os.path.splitext(name)[0],
+        "md5": md5,
     }
 
 


### PR DESCRIPTION
The converter assumes that all images will be of type `jpeg`, however, both Journey and DayOne allow for multiple other types, including `png` and `mp4`. 

If `name = photo.jpg`, `md5, type = os.path.splitext(name)` would return `md5 = photo` and `type = ".jpeg"`, which is why we must strip the first character with `type[1:]`.